### PR TITLE
feat: add interactive roadmap status

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,13 +64,119 @@
       max-height: 100svh;
       display: grid;
       place-items: center;
+      justify-items: center;
       overflow: hidden;
+      gap: 1.75rem;
+      padding: 1.25rem 1.5rem 2.25rem;
+      box-sizing: border-box;
     }
 
     svg {
       width: min(96vw, 96vh);
       height: auto;
       display: block;
+    }
+
+    .roadmap-panel {
+      width: min(520px, 86vw);
+      border-radius: 22px;
+      padding: 1.4rem 1.6rem 1.6rem;
+      background: linear-gradient(160deg, rgba(28, 29, 33, 0.88) 0%, rgba(14, 15, 18, 0.92) 58%, rgba(12, 12, 14, 0.96) 100%);
+      border: 1px solid rgba(255, 222, 158, 0.25);
+      box-shadow: 0 22px 44px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 248, 226, 0.12);
+      color: #f6f2e4;
+      font-family: "Cinzel", "EB Garamond", "Times New Roman", serif;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      backdrop-filter: blur(6px);
+    }
+
+    .roadmap-title {
+      font-size: 0.92rem;
+      opacity: 0.78;
+      margin-bottom: 0.9rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .roadmap-title::before,
+    .roadmap-title::after {
+      content: "";
+      flex: 1 1;
+      height: 1px;
+      background: linear-gradient(90deg, rgba(215, 182, 95, 0), rgba(215, 182, 95, 0.65), rgba(215, 182, 95, 0));
+    }
+
+    .roadmap-title span {
+      flex: 0 0 auto;
+      padding: 0 0.5rem;
+    }
+
+    .roadmap-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.8rem 1.2rem;
+      margin-bottom: 1.2rem;
+    }
+
+    .roadmap-item {
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .roadmap-item .label {
+      font-size: 0.68rem;
+      opacity: 0.68;
+      letter-spacing: 0.14em;
+    }
+
+    .roadmap-item .value {
+      font-size: 1.25rem;
+      color: var(--gold-bright);
+      text-shadow: 0 0 12px rgba(255, 223, 133, 0.45);
+    }
+
+    .roadmap-item .value.season {
+      color: var(--silver-light);
+      text-shadow: none;
+    }
+
+    .roadmap-project {
+      border-top: 1px solid rgba(255, 229, 191, 0.2);
+      padding-top: 1.1rem;
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .roadmap-project .label {
+      font-size: 0.68rem;
+      opacity: 0.68;
+      letter-spacing: 0.14em;
+    }
+
+    .roadmap-project .value {
+      font-size: 1.05rem;
+      color: #f5e6c9;
+      line-height: 1.5;
+      text-shadow: 0 0 18px rgba(255, 214, 132, 0.4);
+    }
+
+    .roadmap-project .note {
+      font-size: 0.78rem;
+      line-height: 1.45;
+      color: rgba(246, 242, 228, 0.78);
+      text-transform: none;
+      letter-spacing: 0.02em;
+    }
+
+    .roadmap-panel.roadmap-panel--empty .value.project {
+      color: rgba(246, 242, 228, 0.8);
+      text-shadow: none;
+    }
+
+    .roadmap-panel.roadmap-panel--empty .note {
+      color: rgba(225, 220, 210, 0.65);
     }
 
     .bg-plate {
@@ -244,6 +350,12 @@
       stroke: url(#snake-gold);
     }
 
+    .snake.active {
+      stroke-width: 44;
+      filter: url(#snakeBevel);
+      opacity: 1;
+    }
+
     .snake-glow {
       fill: none;
       stroke: rgba(255, 255, 255, 0.1);
@@ -296,14 +408,16 @@
     }
 
     .hint {
-      position: absolute;
-      inset: auto 0 1.75rem 0;
+      font-family: "Fira Sans", "Segoe UI", sans-serif;
+      text-transform: uppercase;
+      font-weight: 500;
       text-align: center;
       font-size: 14px;
       opacity: 0.82;
       color: rgba(233, 229, 214, 0.8);
       user-select: none;
-      letter-spacing: 0.08em;
+      letter-spacing: 0.16em;
+      padding: 0 1.8rem;
     }
 
     noscript {
@@ -319,9 +433,29 @@
         letter-spacing: 0.6px;
       }
 
+      .roadmap-panel {
+        width: min(440px, 90vw);
+        padding: 1.2rem 1.2rem 1.4rem;
+        gap: 1rem;
+      }
+
+      .roadmap-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.7rem 1rem;
+      }
+
+      .roadmap-item .value {
+        font-size: 1.05rem;
+      }
+
+      .roadmap-project .value {
+        font-size: 0.96rem;
+      }
+
       .hint {
         font-size: 12px;
         padding: 0 1.4rem;
+        letter-spacing: 0.1em;
       }
     }
   </style>
@@ -532,6 +666,32 @@
               </g>
             </g>
           </svg>
+          <div class="roadmap-panel" aria-live="polite">
+            <div class="roadmap-title"><span>Дорожная карта</span></div>
+            <div class="roadmap-grid">
+              <div class="roadmap-item">
+                <span class="label">Неделя года</span>
+                <span class="value" data-role="week-number">01</span>
+              </div>
+              <div class="roadmap-item">
+                <span class="label">Месяц</span>
+                <span class="value" data-role="month-name">Январь</span>
+              </div>
+              <div class="roadmap-item">
+                <span class="label">Неделя месяца</span>
+                <span class="value" data-role="week-in-month">1-я</span>
+              </div>
+              <div class="roadmap-item">
+                <span class="label">Сезон</span>
+                <span class="value season" data-role="season-name">Зима</span>
+              </div>
+            </div>
+            <div class="roadmap-project">
+              <span class="label">Проект</span>
+              <span class="value project" data-role="project-name">Свободное окно</span>
+              <span class="note" data-role="project-summary">Недельный резерв под срочные инициативы.</span>
+            </div>
+          </div>
           <div class="hint">Потяни за ручку или за проект — колесо шагает по неделям с тонким «щелчком»</div>
         </div>
       `;
@@ -544,8 +704,31 @@
       const snakesGroup = root.querySelector("#snakes");
       const rotor = root.querySelector("#rotor");
       const knob = root.querySelector("#knob-group");
+      const roadmapPanel = root.querySelector(".roadmap-panel");
+      const weekValue = root.querySelector('[data-role="week-number"]');
+      const monthValue = root.querySelector('[data-role="month-name"]');
+      const weekInMonthValue = root.querySelector('[data-role="week-in-month"]');
+      const seasonValue = root.querySelector('[data-role="season-name"]');
+      const projectName = root.querySelector('[data-role="project-name"]');
+      const projectSummary = root.querySelector('[data-role="project-summary"]');
 
-      if (!svg || !dial || !labels || !monthRing || !trackGroup || !snakesGroup || !rotor || !knob) {
+      if (
+        !svg ||
+        !dial ||
+        !labels ||
+        !monthRing ||
+        !trackGroup ||
+        !snakesGroup ||
+        !rotor ||
+        !knob ||
+        !roadmapPanel ||
+        !weekValue ||
+        !monthValue ||
+        !weekInMonthValue ||
+        !seasonValue ||
+        !projectName ||
+        !projectSummary
+      ) {
         throw new Error("Snailendar markup failed to initialise");
       }
 
@@ -574,6 +757,18 @@
       const monthLabelRadius = 437;
       const toRad = (deg) => (deg * Math.PI) / 180;
       const normalizeStep = (step) => ((step % weeks) + weeks) % weeks;
+      const seasonNames = {
+        winter: "Зима",
+        spring: "Весна",
+        summer: "Лето",
+        autumn: "Осень",
+      };
+      const formatWeekNumber = (value) => value.toString().padStart(2, "0");
+      const formatWeekInMonth = (value) => `${value}-я`;
+      const defaultProject = {
+        title: "Свободное окно",
+        summary: "Недельный резерв под срочные инициативы.",
+      };
 
       const arc = (radius, fromDeg, toDeg) => {
         const polar = (angle) => [
@@ -632,7 +827,7 @@
       const weekToMonth = [];
       months.forEach((month, monthIndex) => {
         for (let w = 0; w < month.weeks; w += 1) {
-          weekToMonth.push({ monthIndex, season: month.season });
+          weekToMonth.push({ monthIndex, season: month.season, weekInMonth: w + 1 });
         }
       });
 
@@ -705,17 +900,54 @@
       trackGroup.appendChild(outlineInner);
 
       const snakes = [
-        { cls: "gold", start: 1, len: 4 },
-        { cls: "silver", start: 7, len: 6 },
-        { cls: "gold", start: 15, len: 4 },
-        { cls: "silver", start: 22, len: 7 },
-        { cls: "ruby", start: 33, len: 3 },
-        { cls: "silver", start: 40, len: 7 },
+        {
+          cls: "gold",
+          start: 1,
+          len: 4,
+          title: "Картография корпуса",
+          summary: "Отрисовываем новые дуги месяца и проверяем баланс подсветки.",
+        },
+        {
+          cls: "silver",
+          start: 7,
+          len: 6,
+          title: "Механика фиксации",
+          summary: "Тестируем узел фиксации, добиваемся ровного щелчка на каждом шаге.",
+        },
+        {
+          cls: "gold",
+          start: 15,
+          len: 4,
+          title: "Золотой орнамент",
+          summary: "Инкрустируем сезонные сегменты и обновляем фаску кольца.",
+        },
+        {
+          cls: "silver",
+          start: 22,
+          len: 7,
+          title: "Летний прогресс",
+          summary: "Расширяем трек проектов для летнего блока и усиливаем защиту покрытия.",
+        },
+        {
+          cls: "ruby",
+          start: 33,
+          len: 3,
+          title: "Рубиновый маяк",
+          summary: "Настраиваем индикатор критических спринтов и оповещение о рисках.",
+        },
+        {
+          cls: "silver",
+          start: 40,
+          len: 7,
+          title: "Серебряный резерв",
+          summary: "Резервируем осенние недели под быстрые инициативы и доработки.",
+        },
       ];
 
       const snakeRadius = trackInner + trackWidth / 2;
       const cubeArc = (2 * Math.PI * snakeRadius) / weeks;
       const snakeFragment = document.createDocumentFragment();
+      const snakeEntries = [];
       snakes.forEach((snake) => {
         const start = snake.start * stepDeg + 0.9;
         const end = (snake.start + snake.len) * stepDeg - 0.9;
@@ -725,14 +957,57 @@
         path.setAttribute("stroke-dasharray", `${(cubeArc * 0.72).toFixed(3)} ${(cubeArc * 0.28).toFixed(3)}`);
         path.setAttribute("stroke-dashoffset", (cubeArc * 0.1).toFixed(3));
         snakeFragment.appendChild(path);
+        snakeEntries.push({
+          cls: snake.cls,
+          start: snake.start,
+          len: snake.len,
+          title: snake.title,
+          summary: snake.summary,
+          node: path,
+        });
       });
       snakesGroup.appendChild(snakeFragment);
+
+      const projectLookup = Array.from({ length: weeks }, () => null);
+      snakeEntries.forEach((entry) => {
+        for (let offset = 0; offset < entry.len; offset += 1) {
+          const index = normalizeStep(entry.start + offset);
+          projectLookup[index] = entry;
+        }
+      });
+
+      const updateRoadmap = (step) => {
+        const currentIndex = normalizeStep(step);
+        const info = weekToMonth[currentIndex];
+        if (!info) {
+          return;
+        }
+        const month = months[info.monthIndex];
+        weekValue.textContent = formatWeekNumber(currentIndex + 1);
+        monthValue.textContent = month.label;
+        weekInMonthValue.textContent = formatWeekInMonth(info.weekInMonth);
+        seasonValue.textContent = seasonNames[info.season] || info.season;
+        const project = projectLookup[currentIndex];
+        snakeEntries.forEach((entry) => {
+          entry.node.classList.toggle("active", entry === project);
+        });
+        if (project) {
+          roadmapPanel.classList.remove("roadmap-panel--empty");
+          projectName.textContent = project.title;
+          projectSummary.textContent = project.summary;
+        } else {
+          roadmapPanel.classList.add("roadmap-panel--empty");
+          projectName.textContent = defaultProject.title;
+          projectSummary.textContent = defaultProject.summary;
+        }
+      };
 
       let rot = 0;
       const applyRotation = (value) => {
         rotor.style.transform = `rotate(${value}deg)`;
       };
       applyRotation(rot);
+      updateRoadmap(0);
       let dragging = false;
       let startAngle = 0;
       let baseRot = 0;
@@ -772,6 +1047,7 @@
         startAngle = toAngle(evt);
         baseRot = rot;
         lastSnapIndex = normalizeStep(Math.round(rot / stepDeg));
+        updateRoadmap(lastSnapIndex);
         evt.preventDefault();
       };
 
@@ -781,6 +1057,7 @@
         rot = baseRot + delta;
         applyRotation(rot);
         const snapIndex = normalizeStep(Math.round(rot / stepDeg));
+        updateRoadmap(snapIndex);
         if (snapIndex !== lastSnapIndex) {
           lastSnapIndex = snapIndex;
           tick();
@@ -797,6 +1074,7 @@
         rotor.classList.add("rotating");
         applyRotation(rot);
         lastSnapIndex = normalizedSteps;
+        updateRoadmap(normalizedSteps);
         tick();
       };
 


### PR DESCRIPTION
## Summary
- add a roadmap status panel beneath the dial with responsive styling
- surface per-week details (month, season, project) and highlight the active project while rotating the wheel

## Testing
- Manual testing only (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68da422e78fc8327b5b7d314f0b7e7a8